### PR TITLE
Updated Dockerfile, added facility scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,43 +1,19 @@
-### STAGE 1: Build ###
 FROM mhart/alpine-node:14 as builder
-
-RUN mkdir -p /temp/app
-RUN mkdir -p /app
-
-WORKDIR /app
-
+WORKDIR /tmp
 COPY . .
 
-RUN npm i --no-progress --loglevel=error --unsafe-perm
+RUN npm install --no-progress --loglevel=error --unsafe-perm && npm run build \
+	&& wget -q -O - https://gobinaries.com/tj/node-prune | sh \
+	&& node-prune . \
+	&& npm install --no-progress --production --loglevel=error --production=true --unsafe-perm
 
-RUN npm run build
-
-RUN rm -rf client/*
-
-RUN cp -R /app/server /temp/app
-
-RUN rm -rf /app/*
-
-RUN cp -R /temp/app /app
-
-RUN rm -rf /temp/app
-
-RUN npm i --no-progress --production --loglevel=error --production=true --unsafe-perm
-
-FROM mhart/alpine-node:14
-
-WORKDIR /app
-
-COPY --from=builder /app/app/server .
-
-RUN apk add --no-cache --quiet curl
-
-RUN curl -sf https://gobinaries.com/tj/node-prune | sh
-
-RUN apk del --no-cache --quiet curl
-
-RUN node-prune .
-
+FROM alpine:3.14
+WORKDIR /app/server
+RUN apk add --no-cache nodejs
+COPY --from=builder /tmp/server .
+ARG API_URL
+ARG AUTO_DETECT_BASE_URL
 EXPOSE 3000
-
-CMD node index.js
+ENV NODE_ENV=production
+ENV API_URL=${API_URL}
+CMD [ "node", "index.js" ]

--- a/README.md
+++ b/README.md
@@ -19,3 +19,30 @@ Start the built project:
 Develop:
 
 `npm run start:dev`
+
+
+# Docker
+
+## Build
+
+Build can be easily done by running:
+
+`sh build.sh`
+
+### Build args
+
+`AUTO_DETECT_BASE_URL (default: *false*)`
+
+Leave to *false* if if the timer is running on a FQDN directly, without a subpage (e.g. https://www.example.com)
+
+Set to true if you need to run the timer in an URL like *https://www.example.com/myamazingsharedtimer*
+
+`API_URL (default: not set because autodetected)`
+
+Define the URL where the shared-timer is used, when `AUTO_DETECT_BASE_URL` is set to *true*.
+e.g.: *https://www.example.com/myamazingsharedtimer*
+
+These two variables can be passed during the build phase:
+
+`sh build.sh <true|false> <https://www.example.com/myamazingsharedtimer>`
+

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+AUTO_DETECT_BASE_URL=${1:-false}
+API_URL=${2}
+
+echo "** Please read the README.md to know which vars are used at build time **"
+echo
+echo "==> Building image.."
+
+docker build \
+	-t pontino/shared-timer:${TAG:-0.01} \
+	--build-arg AUTO_DETECT_BASE_URL=${AUTO_DETECT_BASE_URL} \
+	--build-arg API_URL=${API_URL} \
+	--no-cache .

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+#
+EXTPORT=8080
+IMG=pontino/shared-timer
+TAG=0.01
+
+! [ -f ./db.json ] && \
+	echo -e "\n ==> Before running the container, you need to create first a db.json file\n ==> See: https://github.com/pontino/shared-timer/blob/master/server/data/db.json.example\n" && exit 1; 
+
+docker container run --name timer \
+	--mount type=bind,source="$(pwd)"/db.json,target=/app/server/data/db.json \
+	-e NODE_ENV=production \
+	-p ${EXTPORT}:3000 ${IMG}:${TAG}


### PR DESCRIPTION
- The image is now shipped with a multistage build, making the image big 55MB
- `build.sh` and `run.sh` are two script making the process of building and running the container quite easy.

`build.sh` :
**README.md** updated to reflect two ARG used during building phase
`TAG=0.01` is used if not differently specified
`pontino/shared-timer:${TAG}` is the default name of base-image.

`run.sh`:
Dockerfile is shipped without a config file. Check the `run.sh` script for further information